### PR TITLE
empecher de louer ses parents + enlever le bouton quand on a déjà lou…

### DIFF
--- a/app/views/couples/show.html.erb
+++ b/app/views/couples/show.html.erb
@@ -26,6 +26,12 @@
 <p> Parents are already booked ! </p>
 <% end %>
 
-<%= render 'couples/form', booking: Booking.new %>
+<h2>Réservations</h2>
+<% if @couple.user == current_user %>
+  <p>Vous n'allez quand même pas louer vos propres parents...</p>
+<% else %>
+  <%= render 'couples/form', booking: Booking.new %>
+<% end %>
+
 
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>TODO</title>
+    <title>PARHUNT</title>
     <%= csrf_meta_tags %>
     <%= action_cable_meta_tag %>
     <%= stylesheet_link_tag 'application', media: 'all' %>
@@ -21,7 +21,13 @@
         <button type="button" class="btn btn-danger">
           <%= link_to "Voir les parents à louer", couples_path %>
         </button>
-        <button type="button" class="btn btn-danger"> <a href="/couples/new">Louez vos parents</a> </button>
+        <% if current_user.nil? %>
+        <% else %>
+          <% if current_user.couple == nil %>
+            <button type="button" class="btn btn-danger"> <a href="/couples/new">Louez vos parents</a> </button>
+          <% else %>
+          <% end %>
+        <% end %>
 
         <% if current_user.nil? %>
           <button type="button" class="btn btn-secondary"><a href="users/sign_up">Se connecter</a></button>


### PR DESCRIPTION
On ne peut pas loué ses propres parents
+ quand on a déjà mis ses parents à louer, le bouton "louez vos parents" disparait